### PR TITLE
Fix windows title update

### DIFF
--- a/main.c
+++ b/main.c
@@ -188,18 +188,6 @@ void output(struct window_props* wlist, int n, Window active_window, char* execu
 }
 
 void configure_windows_notify(Display* d, struct window_props* prev_wlist, int prev_wlist_len, struct window_props* wlist, int n) {
-    for (int i = 0; i < prev_wlist_len; i++) {
-        bool found = false;
-        for (int j = 0; j < n; j++) {
-            if (prev_wlist[i].id == wlist[j].id) {
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
-            // XSelectInput(d, prev_wlist[i].id, NoEventMask);
-        }
-    }
     for (int i = 0; i < n; i++) {
         bool found = false;
         for (int j = 0; j < prev_wlist_len; j++) {

--- a/main.c
+++ b/main.c
@@ -236,9 +236,8 @@ void spy_root_window(Display* d, char* executable_path) {
         if (e.type == ConfigureNotify || e.type == PropertyNotify) {
             int n;
             struct window_props* wlist = generate_window_list(d, current_desktop_id, &n);
-            output(wlist, n, active_window, executable_path);
-
             configure_windows_notify(d, prev_wlist, prev_wlist_len, wlist, n);
+            output(wlist, n, active_window, executable_path);
 
             free(prev_wlist);
             prev_wlist = wlist;

--- a/main.c
+++ b/main.c
@@ -188,33 +188,27 @@ void output(struct window_props* wlist, int n, Window active_window, char* execu
 }
 
 void configure_windows_notify(Display* d, struct window_props* prev_wlist, int prev_wlist_len, struct window_props* wlist, int n) {
-    if (prev_wlist != NULL) {
-        for (int i = 0; i < prev_wlist_len; i++) {
-            bool found = false;
-            for (int j = 0; j < n; j++) {
-                if (prev_wlist[i].id == wlist[j].id) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                // XSelectInput(d, prev_wlist[i].id, NoEventMask);
+    for (int i = 0; i < prev_wlist_len; i++) {
+        bool found = false;
+        for (int j = 0; j < n; j++) {
+            if (prev_wlist[i].id == wlist[j].id) {
+                found = true;
+                break;
             }
         }
-        for (int i = 0; i < n; i++) {
-            bool found = false;
-            for (int j = 0; j < prev_wlist_len; j++) {
-                if (wlist[i].id == prev_wlist[j].id) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                XSelectInput(d, wlist[i].id, PropertyChangeMask);
+        if (!found) {
+            // XSelectInput(d, prev_wlist[i].id, NoEventMask);
+        }
+    }
+    for (int i = 0; i < n; i++) {
+        bool found = false;
+        for (int j = 0; j < prev_wlist_len; j++) {
+            if (wlist[i].id == prev_wlist[j].id) {
+                found = true;
+                break;
             }
         }
-    } else {
-        for (int i = 0; i < n; i++) {
+        if (!found) {
             XSelectInput(d, wlist[i].id, PropertyChangeMask);
         }
     }
@@ -246,9 +240,7 @@ void spy_root_window(Display* d, char* executable_path) {
 
             configure_windows_notify(d, prev_wlist, prev_wlist_len, wlist, n);
 
-            if (prev_wlist != NULL) {
-                free(prev_wlist);
-            }
+            free(prev_wlist);
             prev_wlist = wlist;
             prev_wlist_len = n;
         }


### PR DESCRIPTION
This tries to fix #6.

We ask the X server to report `PropertyChange` events for visible windows.
This will trigger an event when the title changes, so we can output the windows list with their up-to-date title.

```c
XSelectInput(d, wlist[i].id, PropertyChangeMask);
```

We only call `XSelectInput` on new windows, and avoid calling it multiple times if not needed. This is because `XSelectInput` locks the display ([source](https://github.com/mirror/libX11/blob/ff8706a5eae25b8bafce300527079f68a201d27f/src/SelInput.c#L40)).