### PR TITLE
Handle "none" for fg_color options

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,29 +125,29 @@ All options are detailed below:
             </td>
         </tr>
         <tr>
-            <td><code>active_window_fg_color</code></td>
-            <td>Foreground color for the currently focused window</td>
-            <td align="center">hex color (string)</td>
-        </tr>
-        <tr>
-            <td><code>inactive_window_fg_color</code></td>
-            <td>Foreground color for unfocused windows</td>
-            <td align="center">hex color (string)</td>
-        </tr>
-        <tr>
-            <td><code>separator_fg_color</code></td>
-            <td>Foreground color for the string between window names</td>
-            <td align="center">hex color (string)</td>
-        </tr>
-        <tr>
-            <td><code>empty_desktop_fg_color</code></td>
-            <td>Foreground color for the string shown when no windows are open</td>
-            <td align="center">hex color (string)</td>
-        </tr>
-        <tr>
-            <td><code>overflow_fg_color</code></td>
-            <td>Foreground color for the string that indicates max windows exceeding e.g. <code>(+3)</code></td>
-            <td align="center">hex color (string)</td>
+            <td>
+                <code>active_window_fg_color</code>
+                <code>inactive_window_fg_color</code>
+                <code>separator_fg_color</code>
+                <code>empty_desktop_fg_color</code>
+                <code>overflow_fg_color</code>
+            </td>
+            <td>
+                Foreground colors for:
+                <ul>
+                    <li>Currently focused window</li>
+                    <li>Windows not in focus</li>
+                    <li>The <code>separator_string</code></li>
+                    <li>The <code>empty_desktop_string</code></li>
+                    <li>The string shown when <code>max_windows</code> exceeded</li>
+                </ul>
+            </td>
+            <td>
+                <ul>
+                    <li><code>"none"</code>: default polybar fg</code></li>
+                    <li>hex color (string)</li>
+                </ul>
+            </td>
         </tr>
         <tr>
             <td><code>*_bg_color</code></td>

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ All options are detailed below:
 
 Note: polybar must be reset before changes take effect.
 
+### Defaults
+
+Check the `config.toml` in this repo, the options set there are the default values.
+
+You can also remove any key and it will fall back to the default value.
+
 ### Scripting click actions
 
 The most convenient way is to write a shell script in the `click-actions` directory. Any language could be used, though. There are three "default" actions as small C programs: `raise`, `minimize` and `close`.

--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ inactive_window_right_click  = "close"
 inactive_window_scroll_up    = "none"
 inactive_window_scroll_down  = "none"
 
-active_window_fg_color = "#e0e0e0"
+active_window_fg_color = "none"
 active_window_bg_color = "none"
 active_window_ul_color = "none"
 
@@ -33,11 +33,11 @@ separator_fg_color = "#808080"
 separator_bg_color = "none"
 separator_ul_color = "none"
 
-empty_desktop_fg_color = "#e0e0e0"
+empty_desktop_fg_color = "none"
 empty_desktop_bg_color = "none"
 empty_desktop_ul_color = "none"
 
-overflow_fg_color = "#e8c47b"
+overflow_fg_color = "none"
 overflow_bg_color = "none"
 overflow_ul_color = "none"
 

--- a/main.c
+++ b/main.c
@@ -251,9 +251,15 @@ void print_polybar_str(char* label, char* fg_color, char* bg_color, char* ul_col
         printf("%%{u%s}%%{+u}", ul_color);
     }
 
-    printf("%%{F%s}", fg_color);
+    if (!is_unused(fg_color)) {
+        printf("%%{F%s}", fg_color);
+    }
+
     printf(label);
-    printf("%%{F-}");
+
+    if (!is_unused(fg_color)) {
+        printf("%%{F-}");
+    }
 
     if (!is_unused(ul_color)) {
         printf("%%{-u}");


### PR DESCRIPTION
#19

* [x] Handle `"none"`
* [x] Change defaults
* [x] Clarify defaults in README
    * Probably just say that `config.toml` has the default values, and mention that keys can be removed and it still falls back to default?